### PR TITLE
Remove auth health endpoint nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,12 +12,18 @@ http {
         listen 0.0.0.0:${PORT};
         server_name mlflow;
 
-        # HTTP Basic auth
-        auth_basic "Login required";
-        auth_basic_user_file /etc/nginx/.htpasswd;
+        location = /health {
+            auth_basic "off";
+            proxy_pass http://0.0.0.0:5001;
+            proxy_set_header Host "mlflow";            
+        }
 
         # Forward to MLFlow
         location / {
+            # HTTP Basic auth
+            auth_basic "Login required";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+
             proxy_pass http://0.0.0.0:5001;
             proxy_set_header Host "mlflow";
         }

--- a/terraform/server.tf
+++ b/terraform/server.tf
@@ -46,10 +46,11 @@ resource "aws_apprunner_service" "mlflow_server" {
 
   health_check_configuration {
     healthy_threshold   = 1
+    unhealthy_threshold = 5
     interval            = 20
-    # protocol            = "HTTP"
     timeout             = 20
-    unhealthy_threshold = 20
+    path                = "/health"
+    protocol            = "HTTP"
   }
 
   tags = merge(


### PR DESCRIPTION
In this PR, we are removing the basic authentication from the `/health` endpoint. It's required to properly set up the health check configuration.