### PR TITLE
Update output s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ cd mlflow-server
 3. Run the following command to create all the required resources:
 
 ```bash
-docker-compose up -d
+docker-compose up -d --build
 ```
 
 ## Using your deployed MLflow

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output "artifact_bucket_id" {
-  value = module.s3.artifact_bucket_id
+  value = local.artifact_bucket_id
 }
 
 output "service_url" {


### PR DESCRIPTION
Fixing the `artifact_bucket_id` output when passing an existent bucket.

Fix #173 