### PR TITLE
[ResolutionFailure] with psycopg2-binary and gevent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mlflow==1.30.0
 pymysql==1.0.2
-psycopg2-binary==2.9.4
+psycopg2-binary
 protobuf==4.21.8
-gevent==22.10.1
+gevent
 boto3==1.24.96


### PR DESCRIPTION
the versions proposed of psycopg2-binary and gevent result in ResolutionFailure errors when working with Pipenv.  Without specifiying versions it works and the Pipfile looks like this: [packages]
mlflow = "==1.30.0"
pymysql = "==1.0.2"
protobuf = "==4.21.8"
boto3 = "==1.24.96"
psycopg2-binary = "*"
gevent = "*"